### PR TITLE
Add promise implementation

### DIFF
--- a/conditional-contiunation/lib/userModelPromised.js
+++ b/conditional-contiunation/lib/userModelPromised.js
@@ -1,0 +1,11 @@
+var Q = require('q');
+var userModel = require('./userModel');
+
+module.exports.createUserModel = function() {
+	var user = userModel.createUserModel();
+	return {
+		findByEmail: Q.nfbind(user.findByEmail),
+		findByName: Q.nfbind(user.findByName),
+		findByGithub: Q.nfbind(user.findByGithub)
+	};
+};

--- a/conditional-contiunation/methods/promise.js
+++ b/conditional-contiunation/methods/promise.js
@@ -1,0 +1,29 @@
+var userModel = require('../lib/userModelPromised').createUserModel();
+var Q = require('q');
+
+module.exports.findMe = function(user, callback){
+  Q.resolve(null)
+    .then(function () {
+      return userModel.findByEmail(user.email);
+    })
+    .then(function (result) {
+      return result || userModel.findByName(user.name);
+    })
+    .then(function (result) {
+      return result || userModel.findByGithub(user.github);
+    })
+    .nodeify(callback);
+};
+
+// The following function will work once ES6 comes out:
+/*
+var findMe = Q.async(function* (user) {
+  return (yield userModel.findByEmail(user.email)) ||
+         (yield userModel.findByName(user.name)) ||
+         (yield userModel.findByGithub(user.github)) || null;
+});
+
+module.exports.findMe = function(user, callback){
+  findMe(user).nodeify(callback);
+};
+*/

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "step": "~0.0",
     "async": "~0.1",
     "jangle": "~0.0",
-    "tamejs": "~0.4"
+    "tamejs": "~0.4",
+    "q": "~0.8"
   },
   "devDependencies": {
     "mocha": "~0.11",


### PR DESCRIPTION
I've included a commented out ES6 implementation.  It would throw a syntax error in ES5.

Incidentally, the following would work in Firefox if you specify the JavaScript version appropriately (I think it's 1.8 or something):

``` javascript
var findMe = Q.async(function (user) {
  Q.return((yield userModel.findByEmail(user.email)) ||
         (yield userModel.findByName(user.name)) ||
         (yield userModel.findByGithub(user.github)) || null);
});

module.exports.findMe = function(user, callback){
  findMe(user).nodeify(callback);
};
```

But that isn't compatible with the current ES6 spec since ES6 requries a `*` after the word function if it contains the `yield` keyword and ES6 supports straightforward `return` statements whereas Firefox requires you to throw an exception (Which is what `Q.return` does)
